### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Accessibility for PrimeVue icon-only Buttons
+**Learning:** Found multiple instances across the UI where `Button` components from PrimeVue were used strictly with an `icon` prop (e.g. `icon="pi pi-pencil"`) and no `label` or `aria-label`. Without a descriptive label, screen readers announce these buttons improperly or with confusing terms.
+**Action:** Always ensure icon-only buttons (`Button` tags using icons, native buttons containing icons) have a concise and contextually aware `aria-label` attribute (like "Edit rule" or "Delete category") for proper screen reader accessibility.

--- a/frontend/src/components/Settings/TaggingRulesManager.vue
+++ b/frontend/src/components/Settings/TaggingRulesManager.vue
@@ -50,6 +50,7 @@
             <div class="flex gap-2">
               <Button
                 icon="pi pi-pencil"
+                aria-label="Edit rule"
                 severity="secondary"
                 text
                 rounded
@@ -57,6 +58,7 @@
               />
               <Button
                 icon="pi pi-trash"
+                aria-label="Delete rule"
                 severity="danger"
                 text
                 rounded

--- a/frontend/src/components/Shared/CategoryManagerDialog.vue
+++ b/frontend/src/components/Shared/CategoryManagerDialog.vue
@@ -44,6 +44,7 @@
                 <div class="flex gap-1">
                   <Button
                     icon="pi pi-pencil"
+                    aria-label="Edit category"
                     text
                     rounded
                     severity="secondary"
@@ -51,6 +52,7 @@
                   />
                   <Button
                     icon="pi pi-trash"
+                    aria-label="Delete category"
                     text
                     rounded
                     severity="danger"

--- a/frontend/src/views/InstallmentPlansView.vue
+++ b/frontend/src/views/InstallmentPlansView.vue
@@ -147,6 +147,7 @@
                     </div>
                     <Button
                       icon="pi pi-pencil"
+                      aria-label="Edit installment plan"
                       severity="secondary"
                       text
                       rounded
@@ -154,6 +155,7 @@
                     />
                     <Button
                       :icon="expandedPlans[plan.itemId] ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"
+                      aria-label="Toggle installment plan details"
                       severity="secondary"
                       text
                       rounded
@@ -436,6 +438,7 @@
             <template #body="{ data }">
               <Button
                 icon="pi pi-trash"
+                aria-label="Delete installment"
                 severity="danger"
                 text
                 rounded

--- a/frontend/src/views/SubscriptionsView.vue
+++ b/frontend/src/views/SubscriptionsView.vue
@@ -81,6 +81,7 @@
               <div class="flex justify-end gap-2 opacity-0 group-hover:opacity-100 transition-all">
                 <Button
                   icon="pi pi-pencil"
+                  aria-label="Edit subscription"
                   severity="secondary"
                   text
                   rounded
@@ -88,6 +89,7 @@
                 />
                 <Button
                   icon="pi pi-trash"
+                  aria-label="Delete subscription"
                   severity="danger"
                   text
                   rounded


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple icon-only `Button` components across several views and dialogs.
🎯 Why: Screen readers need textual descriptions for icon-only buttons to announce their purpose correctly.
♿ Accessibility: Improves keyboard and screen-reader accessibility for common actions like Edit, Delete, and Toggle Details.

---
*PR created automatically by Jules for task [13543740178647111939](https://jules.google.com/task/13543740178647111939) started by @niyazmft*