### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,4 @@
 ## 2026-04-11 - Adding aria-labels to PrimeVue Button components
 **Learning:** Found multiple instances where the `<Button>` component was used with just an `icon` attribute (e.g. `icon="pi pi-trash"`) with no child text. This pattern requires adding an `aria-label` attribute directly to the `<Button>` for accessibility purposes so screen readers can describe the button's action.
 **Action:** Always search for `<Button icon="...` without a `label` or inner text and ensure they have a corresponding `aria-label` attribute.
+## 2026-04-12 - Added aria-labels to icon-only buttons\n**Learning:** Icon-only buttons using PrimeVue's <Button> component with only an 'icon' property lack inherent screen-reader accessibility.\n**Action:** Ensure all such buttons are explicitly provided with a descriptive 'aria-label' attribute to improve accessibility and maintain compliance.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,4 +2,6 @@
 ## 2026-04-11 - Adding aria-labels to PrimeVue Button components
 **Learning:** Found multiple instances where the `<Button>` component was used with just an `icon` attribute (e.g. `icon="pi pi-trash"`) with no child text. This pattern requires adding an `aria-label` attribute directly to the `<Button>` for accessibility purposes so screen readers can describe the button's action.
 **Action:** Always search for `<Button icon="...` without a `label` or inner text and ensure they have a corresponding `aria-label` attribute.
-## 2026-04-12 - Added aria-labels to icon-only buttons\n**Learning:** Icon-only buttons using PrimeVue's <Button> component with only an 'icon' property lack inherent screen-reader accessibility.\n**Action:** Ensure all such buttons are explicitly provided with a descriptive 'aria-label' attribute to improve accessibility and maintain compliance.
+## 2026-04-12 - Added aria-labels to icon-only buttons
+**Learning:** Icon-only buttons using PrimeVue's <Button> component with only an 'icon' property lack inherent screen-reader accessibility.
+**Action:** Ensure all such buttons are explicitly provided with a descriptive 'aria-label' attribute to improve accessibility and maintain compliance.

--- a/frontend/src/components/Dashboard/ForecastPanel.vue
+++ b/frontend/src/components/Dashboard/ForecastPanel.vue
@@ -107,6 +107,7 @@
               </div>
               <Button 
                 v-tooltip="'Dismiss for 24 hours'" 
+                aria-label="Dismiss Warning"
                 icon="pi pi-times" 
                 text 
                 rounded 

--- a/frontend/src/components/Dashboard/SavingsGoalsPanel.vue
+++ b/frontend/src/components/Dashboard/SavingsGoalsPanel.vue
@@ -55,6 +55,7 @@
               />
             </div>
             <Button
+              aria-label="Delete Goal"
               icon="pi pi-trash"
               severity="danger"
               text

--- a/frontend/src/components/Settings/ProfileSettings.vue
+++ b/frontend/src/components/Settings/ProfileSettings.vue
@@ -112,6 +112,7 @@
             <Button
               v-if="!isEditingIncome"
               v-tooltip="'Recalculate from Transactions'"
+              aria-label="Recalculate from Transactions"
               icon="pi pi-refresh"
               severity="secondary"
               text
@@ -120,6 +121,7 @@
             <Button
               v-if="!isEditingIncome"
               v-tooltip="'Edit Manually'"
+              aria-label="Edit Manually"
               icon="pi pi-pencil"
               severity="secondary"
               text
@@ -130,11 +132,13 @@
               class="flex gap-2"
             >
               <Button
+                aria-label="Save Income"
                 icon="pi pi-check"
                 severity="success"
                 @click="saveIncomeManually"
               />
               <Button
+                aria-label="Cancel Edit"
                 icon="pi pi-times"
                 severity="danger"
                 text


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only PrimeVue `<Button>` components across several Vue files.
🎯 Why: To improve screen reader support and overall accessibility since these buttons previously lacked descriptive text.
📸 Before/After: Visuals remain unchanged, but the DOM now includes `aria-label` tags for screen readers.
♿ Accessibility: Increased a11y compliance for interactive elements.

---
*PR created automatically by Jules for task [18403443194821524496](https://jules.google.com/task/18403443194821524496) started by @niyazmft*