### PR TITLE
fix(logger): ensure logs directory exists before Winston initialization

### DIFF
--- a/backend/config/logger.js
+++ b/backend/config/logger.js
@@ -1,9 +1,21 @@
 const winston = require('winston');
 require('winston-daily-rotate-file');
 const path = require('path');
+const fs = require('fs');
 
 // Determine log level from environment variable, default to 'info'
 const level = process.env.LOG_LEVEL || 'info';
+
+// Ensure logs directory exists
+const logsDir = path.join(__dirname, '../logs');
+try {
+  if (!fs.existsSync(logsDir)) {
+    fs.mkdirSync(logsDir, { recursive: true });
+  }
+} catch (err) {
+   
+  console.error('Warning: Could not create logs directory:', err.message);
+}
 
 // Define different logging formats
 const consoleFormat = winston.format.combine(


### PR DESCRIPTION
This PR fixes the PM2/Winston logger error that occurs when the app is run from a different working directory.

## Problem
When running with PM2, Winston Daily Rotate File was trying to create `/Volumes/external-d/` directory, resulting in:
```
Error: EACCES: permission denied, mkdir '/Volumes/external-hd/'
```

## Solution
- Add fs.mkdirSync with recursive option to create logs directory if it doesn't exist
- Wrapped in try-catch to handle permission issues gracefully
- Works regardless of working directory (PM2, Docker, manual start)

## Testing
- [ ] Test PM2 startup
- [ ] Verify logs are written correctly
- [ ] Check no permission errors in PM2 logs

This is a general fix that benefits all developers using this codebase.