### PR TITLE
🎨 Palette: Add ARIA labels to various icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,4 +1,10 @@
 
 ## 2026-04-11 - Adding aria-labels to PrimeVue Button components
+
 **Learning:** Found multiple instances where the `<Button>` component was used with just an `icon` attribute (e.g. `icon="pi pi-trash"`) with no child text. This pattern requires adding an `aria-label` attribute directly to the `<Button>` for accessibility purposes so screen readers can describe the button's action.
 **Action:** Always search for `<Button icon="...` without a `label` or inner text and ensure they have a corresponding `aria-label` attribute.
+
+## 2026-04-11 - Dynamic ARIA labels in lists
+
+**Learning:** When adding `aria-label` attributes to elements rendered within a `v-for` loop (like edit/delete buttons for a list of items), using static labels (e.g. "Edit budget") causes screen readers to read the same vague label repeatedly. Providing dynamic context (e.g. `'Edit ' + getCategoryName(budget.categories_id) + ' budget'`) is crucial for making the action descriptive and uniquely identifiable.
+**Action:** Always use dynamic bindings (`:aria-label`) for interactive elements inside lists to include item-specific context.

--- a/frontend/src/services/utils.js
+++ b/frontend/src/services/utils.js
@@ -118,7 +118,7 @@ export const calculateMonthsDifference = (startDate, endDate) => {
 export const capitalizeWords = (text) => {
     if (!text || typeof text !== 'string') return text;
     // Split by whitespace to handle Unicode words correctly (fixes "Eğlence" -> "EğLence" bug)
-    return text.split(/\s+/).map((word) => {
+    return text.split(/\s+/).map(word => {
         if (!word) return '';
         return word.charAt(0).toLocaleUpperCase('tr-TR') + word.slice(1).toLocaleLowerCase('tr-TR');
     }).join(' ');

--- a/frontend/src/views/BudgetManagerView.vue
+++ b/frontend/src/views/BudgetManagerView.vue
@@ -113,6 +113,7 @@
                 <div class="flex gap-1">
                   <Button
                     icon="pi pi-pencil"
+                    aria-label="Edit budget"
                     severity="secondary"
                     text
                     rounded
@@ -120,6 +121,7 @@
                   />
                   <Button
                     icon="pi pi-trash"
+                    aria-label="Delete budget"
                     severity="danger"
                     text
                     rounded

--- a/frontend/src/views/BudgetManagerView.vue
+++ b/frontend/src/views/BudgetManagerView.vue
@@ -113,7 +113,7 @@
                 <div class="flex gap-1">
                   <Button
                     icon="pi pi-pencil"
-                    aria-label="Edit budget"
+                    :aria-label="'Edit ' + getCategoryName(budget.categories_id) + ' budget'"
                     severity="secondary"
                     text
                     rounded
@@ -121,7 +121,7 @@
                   />
                   <Button
                     icon="pi pi-trash"
-                    aria-label="Delete budget"
+                    :aria-label="'Delete ' + getCategoryName(budget.categories_id) + ' budget'"
                     severity="danger"
                     text
                     rounded

--- a/frontend/src/views/InstallmentPlansView.vue
+++ b/frontend/src/views/InstallmentPlansView.vue
@@ -147,7 +147,7 @@
                     </div>
                     <Button
                       icon="pi pi-pencil"
-                      aria-label="Edit plan"
+                      :aria-label="'Edit ' + plan.planName + ' plan'"
                       severity="secondary"
                       text
                       rounded
@@ -155,7 +155,7 @@
                     />
                     <Button
                       :icon="expandedPlans[plan.itemId] ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"
-                      aria-label="Toggle details"
+                      :aria-label="'Toggle details for ' + plan.planName"
                       severity="secondary"
                       text
                       rounded
@@ -438,7 +438,7 @@
             <template #body="{ data }">
               <Button
                 icon="pi pi-trash"
-                aria-label="Delete installment"
+                :aria-label="'Delete installment due on ' + formatDateDisplay(data.start_date)"
                 severity="danger"
                 text
                 rounded

--- a/frontend/src/views/InstallmentPlansView.vue
+++ b/frontend/src/views/InstallmentPlansView.vue
@@ -147,6 +147,7 @@
                     </div>
                     <Button
                       icon="pi pi-pencil"
+                      aria-label="Edit plan"
                       severity="secondary"
                       text
                       rounded
@@ -154,6 +155,7 @@
                     />
                     <Button
                       :icon="expandedPlans[plan.itemId] ? 'pi pi-chevron-up' : 'pi pi-chevron-down'"
+                      aria-label="Toggle details"
                       severity="secondary"
                       text
                       rounded
@@ -436,6 +438,7 @@
             <template #body="{ data }">
               <Button
                 icon="pi pi-trash"
+                aria-label="Delete installment"
                 severity="danger"
                 text
                 rounded

--- a/frontend/src/views/SubscriptionsView.vue
+++ b/frontend/src/views/SubscriptionsView.vue
@@ -81,6 +81,7 @@
               <div class="flex justify-end gap-2 opacity-0 group-hover:opacity-100 transition-all">
                 <Button
                   icon="pi pi-pencil"
+                  aria-label="Edit subscription"
                   severity="secondary"
                   text
                   rounded
@@ -88,6 +89,7 @@
                 />
                 <Button
                   icon="pi pi-trash"
+                  aria-label="Delete subscription"
                   severity="danger"
                   text
                   rounded

--- a/frontend/src/views/SubscriptionsView.vue
+++ b/frontend/src/views/SubscriptionsView.vue
@@ -81,7 +81,7 @@
               <div class="flex justify-end gap-2 opacity-0 group-hover:opacity-100 transition-all">
                 <Button
                   icon="pi pi-pencil"
-                  aria-label="Edit subscription"
+                  :aria-label="'Edit ' + sub.name + ' subscription'"
                   severity="secondary"
                   text
                   rounded
@@ -89,7 +89,7 @@
                 />
                 <Button
                   icon="pi pi-trash"
-                  aria-label="Delete subscription"
+                  :aria-label="'Delete ' + sub.name + ' subscription'"
                   severity="danger"
                   text
                   rounded


### PR DESCRIPTION
💡 What: Added aria-label attributes to icon-only primevue Button components across several views (BudgetManager, InstallmentPlans, Subscriptions).
🎯 Why: To provide context and description for screen reader users since these buttons lack visible text labels.
📸 Before/After: Visuals remain unchanged; screen readers will now read 'Edit budget', 'Delete budget', 'Toggle details', etc., instead of nothing or generic button roles.
♿ Accessibility: Ensures that all interactive icon-only elements are perceivable to assistive technologies, adhering to WCAG guidelines.

---
*PR created automatically by Jules for task [17673784729397702202](https://jules.google.com/task/17673784729397702202) started by @niyazmft*