### PR TITLE
fix(anomalyService): correctly partition baseline using strict date comparison

### DIFF
--- a/backend/services/anomalyService.js
+++ b/backend/services/anomalyService.js
@@ -54,8 +54,8 @@ const detectSpendingAnomalies = async (userId, sensitivity = 3) => {
     scoringCutoff.setDate(scoringCutoff.getDate() - 30); // Last 30 days are for scoring
 
     // Baseline is everything older than the scoring window (Leakage Fix)
-    const historicalTransactions = spendingTransactions.filter(t => t.date <= scoringCutoff);
-    const recentTransactions = spendingTransactions.filter(t => t.date > scoringCutoff);
+    const historicalTransactions = spendingTransactions.filter(t => t.date < scoringCutoff);
+    const recentTransactions = spendingTransactions.filter(t => t.date >= scoringCutoff);
 
     const categoryAverages = {};
     const categoryCounts = {};

--- a/backend/services/anomalyService.js
+++ b/backend/services/anomalyService.js
@@ -54,8 +54,9 @@ const detectSpendingAnomalies = async (userId, sensitivity = 3) => {
     scoringCutoff.setDate(scoringCutoff.getDate() - 30); // Last 30 days are for scoring
 
     // Baseline is everything older than the scoring window (Leakage Fix)
-    const historicalTransactions = spendingTransactions.filter(t => t.date < scoringCutoff);
-    const recentTransactions = spendingTransactions.filter(t => t.date >= scoringCutoff);
+    const cutoffTimestamp = new Date(scoringCutoff).setHours(0, 0, 0, 0);
+    const historicalTransactions = spendingTransactions.filter(t => t.date.getTime() < cutoffTimestamp);
+    const recentTransactions = spendingTransactions.filter(t => t.date.getTime() >= cutoffTimestamp);
 
     const categoryAverages = {};
     const categoryCounts = {};


### PR DESCRIPTION
Fixes temporal leakage by ensuring the baseline includes transactions strictly older than (`<`) the scoring cutoff, while the scoring window includes transactions on or after (`>=`) the cutoff.

---
*PR created automatically by Jules for task [8856770565463467551](https://jules.google.com/task/8856770565463467551) started by @niyazmft*