### PR TITLE
⚡ Bolt: Parallelize paginated NocoDB API requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-06-02 - [Parallelize NocoDB Pagination]
+
+**Learning:** Sequential `while(true)` loops for fetching paginated records from NocoDB create severe network bottlenecks when dealing with large datasets, as each request must wait for the previous one to complete.
+**Action:** The NocoDB API response includes a `pageInfo` object with a `totalRows` property. Use this to calculate the total number of pages needed after the first request, and then fetch all subsequent pages concurrently using `Promise.all()`. This changes an O(N) network operation to concurrent calls.

--- a/backend/controllers/reportController.js
+++ b/backend/controllers/reportController.js
@@ -105,20 +105,33 @@ const getMonthlySpending = catchAsync(async (req, res, next) => {
     const dateRangeFilter = `(date,ge,exactDate,${actualStartDate})~and(date,le,exactDate,${actualEndDate})`;
     const whereClause = `${userFilter}~and${categoriesFilter}~and${dateRangeFilter}`;
     
-    const records = [];
-    let offset = 0;
+    let records;
     const pageSize = 1000;
     const MAX_RECORDS = 50000; // Safety limit
-    
-    while (true) {
-        const pageResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: pageSize, offset: offset, sort: 'date' });
-        const pageData = pageResponse.list || [];
-        
-        records.push(...pageData);
-        if (pageData.length < pageSize || records.length >= MAX_RECORDS) {
-            break;
+
+    // ⚡ PERF: Fetch first page to get totalRows, then parallelize remaining requests
+    const initialParams = { limit: pageSize, offset: 0, sort: 'date', where: whereClause };
+    const initialResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, initialParams);
+    records = initialResponse.list || [];
+
+    const totalRows = initialResponse.pageInfo?.totalRows || records.length;
+    const limitRows = Math.min(totalRows, MAX_RECORDS);
+
+    if (limitRows > pageSize) {
+        const promises = [];
+        for (let offset = pageSize; offset < limitRows; offset += pageSize) {
+            promises.push(nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, {
+                limit: pageSize,
+                offset: offset,
+                sort: 'date',
+                where: whereClause
+            }));
         }
-        offset += pageSize;
+
+        const responses = await Promise.all(promises);
+        for (const res of responses) {
+            records.push(...(res.list || []));
+        }
     }
     
     const monthlyTotals = {};
@@ -215,20 +228,33 @@ const getCategorySpending = catchAsync(async (req, res, next) => {
     const dateRangeFilter = `(date,ge,exactDate,${startDate})~and(date,le,exactDate,${endDate})`;
     const whereClause = `${userFilter}~and${categoriesFilter}~and${dateRangeFilter}`;
     
-    const records = [];
-    let offset = 0;
+    let records;
     const pageSize = 1000;
     const MAX_RECORDS = 50000; // Safety limit
-    
-    while (true) {
-        const pageResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: pageSize, offset: offset, sort: 'categories_id' });
-        const pageData = pageResponse.list || [];
-        
-        records.push(...pageData);
-        if (pageData.length < pageSize || records.length >= MAX_RECORDS) {
-            break;
+
+    // ⚡ PERF: Fetch first page to get totalRows, then parallelize remaining requests
+    const initialParams = { limit: pageSize, offset: 0, sort: 'categories_id', where: whereClause };
+    const initialResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, initialParams);
+    records = initialResponse.list || [];
+
+    const totalRows = initialResponse.pageInfo?.totalRows || records.length;
+    const limitRows = Math.min(totalRows, MAX_RECORDS);
+
+    if (limitRows > pageSize) {
+        const promises = [];
+        for (let offset = pageSize; offset < limitRows; offset += pageSize) {
+            promises.push(nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, {
+                limit: pageSize,
+                offset: offset,
+                sort: 'categories_id',
+                where: whereClause
+            }));
         }
-        offset += pageSize;
+
+        const responses = await Promise.all(promises);
+        for (const res of responses) {
+            records.push(...(res.list || []));
+        }
     }
     
     const categoryTotals = {};
@@ -304,20 +330,33 @@ const getCustomRangeSalary = catchAsync(async (req, res, next) => {
     const dateRangeFilter = `(date,ge,exactDate,${startDate})~and(date,le,exactDate,${endDate})`;
     const whereClause = `${userFilter}~and${categoriesFilter}~and${dateRangeFilter}`;
     
-    const records = [];
-    let offset = 0;
+    let records;
     const pageSize = 1000;
     const MAX_RECORDS = 50000; // Safety limit
-    
-    while (true) {
-        const pageResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: pageSize, offset: offset, sort: 'date' });
-        const pageData = pageResponse.list || [];
-        
-        records.push(...pageData);
-        if (pageData.length < pageSize || records.length >= MAX_RECORDS) {
-            break;
+
+    // ⚡ PERF: Fetch first page to get totalRows, then parallelize remaining requests
+    const initialParams = { limit: pageSize, offset: 0, sort: 'date', where: whereClause };
+    const initialResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, initialParams);
+    records = initialResponse.list || [];
+
+    const totalRows = initialResponse.pageInfo?.totalRows || records.length;
+    const limitRows = Math.min(totalRows, MAX_RECORDS);
+
+    if (limitRows > pageSize) {
+        const promises = [];
+        for (let offset = pageSize; offset < limitRows; offset += pageSize) {
+            promises.push(nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, {
+                limit: pageSize,
+                offset: offset,
+                sort: 'date',
+                where: whereClause
+            }));
         }
-        offset += pageSize;
+
+        const responses = await Promise.all(promises);
+        for (const res of responses) {
+            records.push(...(res.list || []));
+        }
     }
     
     const customRangeData = records;

--- a/backend/controllers/reportController.js
+++ b/backend/controllers/reportController.js
@@ -114,7 +114,7 @@ const getMonthlySpending = catchAsync(async (req, res, next) => {
     const initialResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, initialParams);
     records = initialResponse.list || [];
 
-    const totalRows = initialResponse.pageInfo?.totalRows || records.length;
+    const totalRows = initialResponse.pageInfo?.totalRows !== undefined ? initialResponse.pageInfo.totalRows : records.length;
     const limitRows = Math.min(totalRows, MAX_RECORDS);
 
     if (limitRows > pageSize) {

--- a/backend/controllers/reportController.js
+++ b/backend/controllers/reportController.js
@@ -237,7 +237,7 @@ const getCategorySpending = catchAsync(async (req, res, next) => {
     const initialResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, initialParams);
     records = initialResponse.list || [];
 
-    const totalRows = initialResponse.pageInfo?.totalRows || records.length;
+    const totalRows = initialResponse.pageInfo?.totalRows !== undefined ? initialResponse.pageInfo.totalRows : records.length;
     const limitRows = Math.min(totalRows, MAX_RECORDS);
 
     if (limitRows > pageSize) {

--- a/backend/controllers/reportController.js
+++ b/backend/controllers/reportController.js
@@ -339,7 +339,7 @@ const getCustomRangeSalary = catchAsync(async (req, res, next) => {
     const initialResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, initialParams);
     records = initialResponse.list || [];
 
-    const totalRows = initialResponse.pageInfo?.totalRows || records.length;
+    const totalRows = initialResponse.pageInfo?.totalRows !== undefined ? initialResponse.pageInfo.totalRows : records.length;
     const limitRows = Math.min(totalRows, MAX_RECORDS);
 
     if (limitRows > pageSize) {

--- a/backend/services/transactionService.js
+++ b/backend/services/transactionService.js
@@ -18,32 +18,40 @@ async function getTransactions(userId, { startDate, endDate }) {
         whereClause = `${userFilter}~and${dateRangeFilter}`;
     }
 
-    let allRecords = [];
-    let currentOffset = 0;
+    let allRecords;
     const pageSize = 1000;
 
-    // Fetch all pages
-    while (true) {
-        const params = {
-            limit: pageSize,
-            offset: currentOffset,
-            sort: '-date',
-            where: whereClause,
-        };
+    // Fetch first page to get total rows
+    const initialParams = {
+        limit: pageSize,
+        offset: 0,
+        sort: '-date',
+        where: whereClause,
+    };
+    const initialResponse = await nocodbService.getRecords(bankStatementsTableId, initialParams);
+    allRecords = initialResponse.list || [];
 
-        const response = await nocodbService.getRecords(bankStatementsTableId, params);
-        const pageRecords = response.list || [];
+    const totalRows = initialResponse.pageInfo?.totalRows || allRecords.length;
+    const MAX_RECORDS = 50000;
+    const limitRows = Math.min(totalRows, MAX_RECORDS);
+
+    if (limitRows > pageSize) {
+        const promises = [];
+        for (let offset = pageSize; offset < limitRows; offset += pageSize) {
+            promises.push(
+                nocodbService.getRecords(bankStatementsTableId, {
+                    limit: pageSize,
+                    offset: offset,
+                    sort: '-date',
+                    where: whereClause,
+                })
+            );
+        }
         
-        if (pageRecords.length === 0) break;
-        
-        allRecords = allRecords.concat(pageRecords);
-        
-        if (pageRecords.length < pageSize) break;
-        
-        currentOffset += pageSize;
-        
-        // Safety check to prevent infinite loops or OOM
-        if (currentOffset > 50000) break;
+        const responses = await Promise.all(promises);
+        for (const res of responses) {
+            allRecords = allRecords.concat(res.list || []);
+        }
     }
 
     // Process and format transactions

--- a/backend/services/transactionService.js
+++ b/backend/services/transactionService.js
@@ -31,7 +31,7 @@ async function getTransactions(userId, { startDate, endDate }) {
     const initialResponse = await nocodbService.getRecords(bankStatementsTableId, initialParams);
     allRecords = initialResponse.list || [];
 
-    const totalRows = initialResponse.pageInfo?.totalRows || allRecords.length;
+    const totalRows = initialResponse.pageInfo?.totalRows !== undefined ? initialResponse.pageInfo.totalRows : allRecords.length;
     const MAX_RECORDS = 50000;
     const limitRows = Math.min(totalRows, MAX_RECORDS);
 


### PR DESCRIPTION
💡 What: Replaced sequential `while(true)` loops for paginated NocoDB API requests with a concurrent `Promise.all` batching strategy based on the `pageInfo.totalRows` returned in the first request.
🎯 Why: Sequential fetching creates a severe N+1-style network bottleneck. By determining the total pages needed upfront, requests can run simultaneously.
📊 Impact: Expected to significantly reduce total load time for retrieving large datasets. Changes a theoretically O(N) network operation into concurrent API requests.
🔬 Measurement: Run reports fetching large datasets (> 1000 items) and compare the total time taken to resolve API calls. Time should drastically decrease.

---
*PR created automatically by Jules for task [1247652873952404371](https://jules.google.com/task/1247652873952404371) started by @niyazmft*