### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/components/Dashboard/ForecastPanel.vue
+++ b/frontend/src/components/Dashboard/ForecastPanel.vue
@@ -107,7 +107,8 @@
               </div>
               <Button 
                 v-tooltip="'Dismiss for 24 hours'" 
-                icon="pi pi-times" 
+                icon="pi pi-times"
+                aria-label="Dismiss warning"
                 text 
                 rounded 
                 severity="secondary" 

--- a/frontend/src/components/Dashboard/SavingsGoalsPanel.vue
+++ b/frontend/src/components/Dashboard/SavingsGoalsPanel.vue
@@ -56,6 +56,7 @@
             </div>
             <Button
               icon="pi pi-trash"
+              :aria-label="'Delete ' + goal.goal_name + ' goal'"
               severity="danger"
               text
               rounded

--- a/frontend/src/components/Settings/TaggingRulesManager.vue
+++ b/frontend/src/components/Settings/TaggingRulesManager.vue
@@ -50,7 +50,7 @@
             <div class="flex gap-2">
               <Button
                 icon="pi pi-pencil"
-                aria-label="Edit rule"
+                :aria-label="'Edit rule for ' + rule.keyword"
                 severity="secondary"
                 text
                 rounded
@@ -58,7 +58,7 @@
               />
               <Button
                 icon="pi pi-trash"
-                aria-label="Delete rule"
+                :aria-label="'Delete rule for ' + rule.keyword"
                 severity="danger"
                 text
                 rounded

--- a/frontend/src/components/Shared/CategoryManagerDialog.vue
+++ b/frontend/src/components/Shared/CategoryManagerDialog.vue
@@ -44,7 +44,7 @@
                 <div class="flex gap-1">
                   <Button
                     icon="pi pi-pencil"
-                    :aria-label="'Edit ' + data.name + ' category'"
+                    :aria-label="'Edit ' + data.category_name + ' category'"
                     text
                     rounded
                     severity="secondary"
@@ -52,7 +52,7 @@
                   />
                   <Button
                     icon="pi pi-trash"
-                    :aria-label="'Delete ' + data.name + ' category'"
+                    :aria-label="'Delete ' + data.category_name + ' category'"
                     text
                     rounded
                     severity="danger"

--- a/frontend/src/components/Shared/CategoryManagerDialog.vue
+++ b/frontend/src/components/Shared/CategoryManagerDialog.vue
@@ -44,7 +44,7 @@
                 <div class="flex gap-1">
                   <Button
                     icon="pi pi-pencil"
-                    aria-label="Edit category"
+                    :aria-label="'Edit ' + data.name + ' category'"
                     text
                     rounded
                     severity="secondary"
@@ -52,7 +52,7 @@
                   />
                   <Button
                     icon="pi pi-trash"
-                    aria-label="Delete category"
+                    :aria-label="'Delete ' + data.name + ' category'"
                     text
                     rounded
                     severity="danger"

--- a/frontend/src/components/Transactions/TransactionList.vue
+++ b/frontend/src/components/Transactions/TransactionList.vue
@@ -67,14 +67,14 @@
           <div class="flex gap-3">
             <button
               class="text-text-muted hover:text-primary p-1"
-              aria-label="Edit transaction"
+              :aria-label="'Edit ' + transaction.description + ' transaction'"
               @click="$emit('edit', transaction)"
             >
               <i class="pi pi-pencil text-sm" /> 
             </button>
             <button
               class="text-text-muted hover:text-danger p-1"
-              aria-label="Delete transaction"
+              :aria-label="'Delete ' + transaction.description + ' transaction'"
               @click="$emit('delete', transaction)"
             >
               <i class="pi pi-trash text-sm" />

--- a/frontend/src/components/Transactions/TransactionTable.vue
+++ b/frontend/src/components/Transactions/TransactionTable.vue
@@ -147,14 +147,14 @@
         <div class="flex gap-2">
           <Button
             icon="pi pi-pencil"
-            aria-label="Edit transaction"
+            :aria-label="'Edit ' + slotProps.data.description + ' transaction'"
             text
             class="text-gray-400 hover:text-blue-500 transition-colors"
             @click="$emit('edit', slotProps.data)"
           />
           <Button
             icon="pi pi-trash"
-            aria-label="Delete transaction"
+            :aria-label="'Delete ' + slotProps.data.description + ' transaction'"
             text
             class="text-gray-400 hover:text-red-500 transition-colors"
             @click="$emit('delete', slotProps.data)"

--- a/frontend/src/views/SpendingAnalysisView.vue
+++ b/frontend/src/views/SpendingAnalysisView.vue
@@ -17,6 +17,7 @@
         />
         <Button
           icon="pi pi-refresh"
+          aria-label="Refresh data"
           severity="secondary"
           outlined
           @click="refreshData"


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to icon-only buttons across multiple components, including dynamically binding labels in lists.

🎯 **Why:** To improve accessibility for screen reader users by providing descriptive actions for buttons that otherwise only have visual icon representations.

📸 **Before/After:** Not applicable (accessibility-only change).

♿ **Accessibility:** This directly resolves issues where screen readers would read unhelpful or missing descriptions for key actions like Edit, Delete, Refresh, and Dismiss.

---
*PR created automatically by Jules for task [14727233249507022182](https://jules.google.com/task/14727233249507022182) started by @niyazmft*