### PR TITLE
⚡ Bolt: Refactor NocoDB fetches to use concurrent Promise.all

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-06-03 - [Parallel Paginated NocoDB Fetches]
+
+**Learning:** Sequential `while (true)` loops for API pagination block the event loop and increase latency linearly with page count (O(N) network roundtrips). NocoDB's `pageInfo.totalRows` allows pre-calculating necessary pages for concurrent execution.
+**Action:** Always extract the total page count on the first request and use `Promise.all` to fetch the remaining pages concurrently, reducing total fetch time to approximately O(1) network roundtrip time, while preserving data order.

--- a/backend/controllers/reportController.js
+++ b/backend/controllers/reportController.js
@@ -105,21 +105,7 @@ const getMonthlySpending = catchAsync(async (req, res, next) => {
     const dateRangeFilter = `(date,ge,exactDate,${actualStartDate})~and(date,le,exactDate,${actualEndDate})`;
     const whereClause = `${userFilter}~and${categoriesFilter}~and${dateRangeFilter}`;
     
-    const records = [];
-    let offset = 0;
-    const pageSize = 1000;
-    const MAX_RECORDS = 50000; // Safety limit
-
-    while (true) {
-        const pageResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: pageSize, offset: offset, sort: 'date' });
-        const pageData = pageResponse.list || [];
-
-        records.push(...pageData);
-        if (pageData.length < pageSize || records.length >= MAX_RECORDS) {
-            break;
-        }
-        offset += pageSize;
-    }
+    const records = await nocodbService.getAllRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: 1000, sort: 'date' });
     
     const monthlyTotals = {};
     let currentMonth = new Date(actualStartDate);
@@ -215,21 +201,7 @@ const getCategorySpending = catchAsync(async (req, res, next) => {
     const dateRangeFilter = `(date,ge,exactDate,${startDate})~and(date,le,exactDate,${endDate})`;
     const whereClause = `${userFilter}~and${categoriesFilter}~and${dateRangeFilter}`;
     
-    const records = [];
-    let offset = 0;
-    const pageSize = 1000;
-    const MAX_RECORDS = 50000; // Safety limit
-
-    while (true) {
-        const pageResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: pageSize, offset: offset, sort: 'categories_id' });
-        const pageData = pageResponse.list || [];
-
-        records.push(...pageData);
-        if (pageData.length < pageSize || records.length >= MAX_RECORDS) {
-            break;
-        }
-        offset += pageSize;
-    }
+    const records = await nocodbService.getAllRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: 1000, sort: 'categories_id' });
     
     const categoryTotals = {};
     targetCategories.forEach(catId => {
@@ -304,21 +276,7 @@ const getCustomRangeSalary = catchAsync(async (req, res, next) => {
     const dateRangeFilter = `(date,ge,exactDate,${startDate})~and(date,le,exactDate,${endDate})`;
     const whereClause = `${userFilter}~and${categoriesFilter}~and${dateRangeFilter}`;
     
-    const records = [];
-    let offset = 0;
-    const pageSize = 1000;
-    const MAX_RECORDS = 50000; // Safety limit
-
-    while (true) {
-        const pageResponse = await nocodbService.getRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: pageSize, offset: offset, sort: 'date' });
-        const pageData = pageResponse.list || [];
-
-        records.push(...pageData);
-        if (pageData.length < pageSize || records.length >= MAX_RECORDS) {
-            break;
-        }
-        offset += pageSize;
-    }
+    const records = await nocodbService.getAllRecords(BANK_STATEMENTS_TABLE_ID, { where: whereClause, limit: 1000, sort: 'date' });
     
     const customRangeData = records;
     

--- a/backend/services/anomalyService.js
+++ b/backend/services/anomalyService.js
@@ -9,30 +9,7 @@ async function fetchAllTransactions(userId) {
     const tableId = env.NOCODB.TABLES.BANK_STATEMENTS;
     const whereClause = `(user_id,eq,${userId})`;
     const pageSize = 1000;
-    const response = await nocodbService.getRecords(tableId, {
-        limit: pageSize,
-        offset: 0,
-        where: whereClause
-    });
-
-    let allRecords = response.list || [];
-    const totalRows = response.pageInfo?.totalRows || allRecords.length;
-
-    if (totalRows > pageSize) {
-        const promises = [];
-        for (let offset = pageSize; offset < totalRows; offset += pageSize) {
-            promises.push(nocodbService.getRecords(tableId, {
-                limit: pageSize,
-                offset,
-                where: whereClause
-            }));
-        }
-
-        const responses = await Promise.all(promises);
-        for (const res of responses) {
-            allRecords = allRecords.concat(res.list || []);
-        }
-    }
+    const allRecords = await nocodbService.getAllRecords(tableId, { limit: pageSize, where: whereClause });
     return allRecords;
 }
 

--- a/backend/services/nocodbService.js
+++ b/backend/services/nocodbService.js
@@ -20,8 +20,9 @@ const getAllRecords = async (tableId, params = {}) => {
     // Initial request to get first page and total count
     const initialResponse = await module.exports.getRecords(tableId, { ...params, limit: pageSize, offset: 0 });
 
-    let allRecords = initialResponse.list || [];
-    const totalRows = initialResponse.pageInfo?.totalRows || allRecords.length;
+    let allRecords = initialResponse?.list || [];
+    const MAX_RECORDS = 50000; // Safety limit to prevent OOM / rate limiting
+    const totalRows = Math.min(initialResponse?.pageInfo?.totalRows || allRecords.length, MAX_RECORDS);
 
     if (totalRows > pageSize) {
         const promises = [];

--- a/backend/services/nocodbService.js
+++ b/backend/services/nocodbService.js
@@ -14,6 +14,30 @@ const getRecords = async (tableId, params) => {
     return response.data;
 };
 
+const getAllRecords = async (tableId, params = {}) => {
+    const pageSize = params.limit || 1000;
+
+    // Initial request to get first page and total count
+    const initialResponse = await module.exports.getRecords(tableId, { ...params, limit: pageSize, offset: 0 });
+
+    let allRecords = initialResponse.list || [];
+    const totalRows = initialResponse.pageInfo?.totalRows || allRecords.length;
+
+    if (totalRows > pageSize) {
+        const promises = [];
+        for (let offset = pageSize; offset < totalRows; offset += pageSize) {
+            promises.push(module.exports.getRecords(tableId, { ...params, limit: pageSize, offset }));
+        }
+
+        const responses = await Promise.all(promises);
+        for (const res of responses) {
+            allRecords = allRecords.concat(res.list || []);
+        }
+    }
+
+    return allRecords;
+};
+
 const createRecord = async (tableId, data) => {
     const url = `${nocodbApiUrl}/api/v2/tables/${tableId}/records`;
     try {
@@ -47,6 +71,7 @@ const getRecordById = async (tableId, recordId) => {
 
 module.exports = {
     getRecords,
+    getAllRecords,
     createRecord,
     updateRecord,
     deleteRecord,

--- a/backend/services/transactionService.js
+++ b/backend/services/transactionService.js
@@ -18,33 +18,7 @@ async function getTransactions(userId, { startDate, endDate }) {
         whereClause = `${userFilter}~and${dateRangeFilter}`;
     }
 
-    let allRecords = [];
-    let currentOffset = 0;
-    const pageSize = 1000;
-
-    // Fetch all pages
-    while (true) {
-        const params = {
-            limit: pageSize,
-            offset: currentOffset,
-            sort: '-date',
-            where: whereClause,
-        };
-
-        const response = await nocodbService.getRecords(bankStatementsTableId, params);
-        const pageRecords = response.list || [];
-        
-        if (pageRecords.length === 0) break;
-
-        allRecords = allRecords.concat(pageRecords);
-
-        if (pageRecords.length < pageSize) break;
-
-        currentOffset += pageSize;
-
-        // Safety check to prevent infinite loops or OOM
-        if (currentOffset > 50000) break;
-    }
+    const allRecords = await nocodbService.getAllRecords(bankStatementsTableId, { limit: 1000, sort: '-date', where: whereClause });
 
     // Process and format transactions
     const transactions = allRecords.map(record => ({

--- a/backend/tests/transactionService.test.js
+++ b/backend/tests/transactionService.test.js
@@ -7,10 +7,12 @@ const env = require('../config/env');
 
 describe('Transaction Service', () => {
     let getRecordsStub;
+    let getAllRecordsStub;
     let getCategoryMappingStub;
 
     beforeEach(() => {
         getRecordsStub = sinon.stub(nocodbService, 'getRecords');
+        if (nocodbService.getAllRecords) { getAllRecordsStub = sinon.stub(nocodbService, 'getAllRecords'); } else { nocodbService.getAllRecords = () => {}; getAllRecordsStub = sinon.stub(nocodbService, 'getAllRecords'); }
         getCategoryMappingStub = sinon.stub(categoryService, 'getCategoryMapping');
     });
 
@@ -38,14 +40,14 @@ describe('Transaction Service', () => {
             10: 'Groceries'
         };
 
-        getRecordsStub.resolves(mockRecords);
+        getAllRecordsStub.resolves(mockRecords.list);
         getCategoryMappingStub.resolves(mockCategoryMapping);
 
         const result = await transactionService.getTransactions(userId, {});
 
         // Verify NocoDB call
-        assert.ok(getRecordsStub.calledOnce);
-        const callArgs = getRecordsStub.firstCall.args;
+        assert.ok(getAllRecordsStub.calledOnce);
+        const callArgs = getAllRecordsStub.firstCall.args;
         assert.strictEqual(callArgs[0], env.NOCODB.TABLES.BANK_STATEMENTS);
         assert.ok(callArgs[1].where.includes(`(user_id,eq,${userId})`));
 
@@ -60,22 +62,13 @@ describe('Transaction Service', () => {
         const userId = 'user123';
         
         // Mock first page (full page)
-        getRecordsStub.onFirstCall().resolves({
-            list: Array(1000).fill({ Id: 1, amount: 10 }),
-            pageInfo: { totalRows: 1001 }
-        });
-        
-        // Mock second page (remaining)
-        getRecordsStub.onSecondCall().resolves({
-            list: [{ Id: 2, amount: 10 }],
-            pageInfo: { totalRows: 1001 }
-        });
+        getAllRecordsStub.resolves(Array(1001).fill({ Id: 1, amount: 10 }));
 
         getCategoryMappingStub.resolves({});
 
         const result = await transactionService.getTransactions(userId, {});
 
-        assert.ok(getRecordsStub.calledTwice);
+        assert.ok(getAllRecordsStub.calledOnce);
         assert.strictEqual(result.transactions.length, 1001);
     });
 

--- a/backend/tests/transactionService.test.js
+++ b/backend/tests/transactionService.test.js
@@ -12,7 +12,7 @@ describe('Transaction Service', () => {
 
     beforeEach(() => {
         getRecordsStub = sinon.stub(nocodbService, 'getRecords');
-        if (nocodbService.getAllRecords) { getAllRecordsStub = sinon.stub(nocodbService, 'getAllRecords'); } else { nocodbService.getAllRecords = () => {}; getAllRecordsStub = sinon.stub(nocodbService, 'getAllRecords'); }
+        getAllRecordsStub = sinon.stub(nocodbService, 'getAllRecords');
         getCategoryMappingStub = sinon.stub(categoryService, 'getCategoryMapping');
     });
 

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,5 +1,0 @@
-🚨 Severity: HIGH
-💡 Vulnerability: Missing rate limiting on sensitive public endpoints (e.g., `/api/request-password-reset`) which could lead to Denial of Service (DoS) attacks and user enumeration/email flooding.
-🎯 Impact: An attacker could write a script to rapidly request password resets, causing a denial of service on the email-sending service or enabling the enumeration of existing accounts through inference or brute-force tracking.
-🔧 Fix: Added custom in-memory `createRateLimiter` middleware (configured for 5 requests per 15 minutes) to the `/request-password-reset` route.
-✅ Verification: Tested the application manually to verify normal requests work, and test suites (`pnpm test` / `pnpm lint`) are passing. Sending more than 5 password reset requests within a 15-minute window will now be rejected.

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,4 @@
+💡 What: Replaced sequential `while (true)` loops for NocoDB paginated fetches with a concurrent `Promise.all` approach in `nocodbService.getAllRecords()`.
+🎯 Why: Sequential pagination blocked the event loop and caused O(N) network roundtrips. Fetching pages concurrently drastically reduces latency.
+📊 Impact: Reduces network request time from O(N) to roughly O(1) roundtrip for large dataset fetches (e.g., custom range salary, monthly spending, and transactions retrieval), improving overall performance.
+🔬 Measurement: Verify by executing queries returning multiple pages in NocoDB, and measuring API response time compared to previous queries (which took up to 50 iterations sequentially).


### PR DESCRIPTION
💡 What: Replaced sequential `while (true)` loops for NocoDB paginated fetches with a concurrent `Promise.all` approach in `nocodbService.getAllRecords()`.
🎯 Why: Sequential pagination blocked the event loop and caused O(N) network roundtrips. Fetching pages concurrently drastically reduces latency.
📊 Impact: Reduces network request time from O(N) to roughly O(1) roundtrip for large dataset fetches (e.g., custom range salary, monthly spending, and transactions retrieval), improving overall performance.
🔬 Measurement: Verify by executing queries returning multiple pages in NocoDB, and measuring API response time compared to previous queries (which took up to 50 iterations sequentially).

---
*PR created automatically by Jules for task [14370347732041944442](https://jules.google.com/task/14370347732041944442) started by @niyazmft*